### PR TITLE
Add Dockerfile + RAxML-NG

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 FROM continuumio/miniconda3:latest
-RUN git clone https://github.com/balabanmetin/uDance.git && \
+RUN conda install openjdk && \
+    git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
     bash install.sh && \
     conda activate udance && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,6 @@ RUN apt-get update -qq && apt-get upgrade -qq -y && \
     apt-get install -qq -y default-jdk && \
     git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
-    bash install.sh && \
-    conda activate udance && \
-    echo "conda activate udance" >> ~/.bashrc
-ENTRYPOINT ["bash", "-l", "-c"]
+    bash install.sh
+    #echo "conda activate udance" >> ~/.bashrc
+#ENTRYPOINT ["bash", "-l", "-c"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,5 +2,7 @@ FROM continuumio/miniconda3:latest
 RUN git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
     bash install.sh && \
+    conda activate udance && \
+    conda install raxml-ng && \
     echo "conda activate udance" >> ~/.bashrc
 ENTRYPOINT ["bash", "-l", "-c"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3:latest
 RUN apt-get update -qq && apt-get upgrade -qq -y && \
-    apt-get install -qq -y default-jdk && \
+    apt-get install -qq -y default-jdk rsync && \
     git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
     bash install.sh && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,6 @@ RUN apt-get update -qq && apt-get upgrade -qq -y && \
     apt-get install -qq -y default-jdk && \
     git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
-    bash install.sh
-    #echo "conda activate udance" >> ~/.bashrc
-#ENTRYPOINT ["bash", "-l", "-c"]
+    bash install.sh && \
+    echo "source activate udance" > ~/.bashrc
+ENV PATH /opt/conda/envs/udance/bin:$PATH

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 FROM continuumio/miniconda3:latest
-RUN conda install -y openjdk && \
+RUN apt-get update -qq && apt-get upgrade -qq -y && \
+    apt-get install -qq -y default-jdk && \
     git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
     bash install.sh && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM continuumio/miniconda3:latest
+RUN git clone https://github.com/balabanmetin/uDance.git && \
+    cd uDance && \
+    bash install.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,5 @@ RUN git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
     bash install.sh && \
     conda activate udance && \
-    conda install raxml-ng && \
     echo "conda activate udance" >> ~/.bashrc
 ENTRYPOINT ["bash", "-l", "-c"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
 FROM continuumio/miniconda3:latest
 RUN git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
-    bash install.sh
+    bash install.sh && \
+    echo "conda activate udance" >> ~/.bashrc
+ENTRYPOINT ["bash", "-l", "-c"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 FROM continuumio/miniconda3:latest
-RUN conda install openjdk && \
+RUN conda install -y openjdk && \
     git clone https://github.com/balabanmetin/uDance.git && \
     cd uDance && \
     bash install.sh && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ uDance is highly-scalable end-to-end workflow for inferring phylogenomic trees o
 3.  `bash install.sh`
 4.  `conda activate udance`
 
-If you want to use raxml-ng in your workflow, please install raxml-ng manually and make sure the executable `raxml-ng` is available in your path.
-
 ## Quick start
 
 You can run uDance on the **test dataset** with 10 gene multiple sequence alignments, 99 backbone sequences, and 146 query sequences using the following command. The command should complete in several minutes using 4 CPU cores:

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ export SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd
 if conda info --envs | grep "udance" > /dev/null; then
         echo "conda environment udance exists"
 else
-	basecomm=$(echo conda create -y -c bioconda -c conda-forge --channel smirarab --name udance python=3.9  pip newick_utils=1.6 setuptools seqkit=2.1.0 scipy dendropy=4.5.2 pandas=1.3.0 snakemake raxml=8.2.12 iqtree=2.1.2 treeshrink=1.3.9 fasttree=2.1.10 julia=1.7.1 gappa=0.7.1 trimal=1.4.1 openjdk raxml-ng) 
+	basecomm=$(echo conda create -y -c bioconda -c conda-forge --channel smirarab --name udance python=3.9  pip newick_utils=1.6 setuptools seqkit=2.1.0 scipy dendropy=4.5.2 pandas=1.3.0 snakemake raxml=8.2.12 iqtree=2.1.2 treeshrink=1.3.9 fasttree=2.1.10 julia=1.7.1 gappa=0.7.1 trimal=1.4.1 raxml-ng) 
 	condaplat=$(conda info | grep "platform" | awk '{print $3}')
 	if [ "$condaplat" == "osx-arm64" ] ; then
 		echo "Installing conda environment on Mac OS X Apple Chip platform"
@@ -33,6 +33,7 @@ else
         # install astral
         pushd $SCRIPTS_DIR/uDance/tools/ASTRAL
        	./make.sh > .astralInstallation.log 2>&1
+	conda install openjdk
 	java -D"java.library.path=lib/" -jar native_library_tester.jar
         popd
 fi

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ export SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd
 if conda info --envs | grep "udance" > /dev/null; then
         echo "conda environment udance exists"
 else
-	basecomm=$(echo conda create -y -c bioconda -c conda-forge --channel smirarab --name udance python=3.9  pip newick_utils=1.6 setuptools seqkit=2.1.0 scipy dendropy=4.5.2 pandas=1.3.0 snakemake raxml=8.2.12 iqtree=2.1.2 treeshrink=1.3.9 fasttree=2.1.10 julia=1.7.1 gappa=0.7.1 trimal=1.4.1) 
+	basecomm=$(echo conda create -y -c bioconda -c conda-forge --channel smirarab --name udance python=3.9  pip newick_utils=1.6 setuptools seqkit=2.1.0 scipy dendropy=4.5.2 pandas=1.3.0 snakemake raxml=8.2.12 iqtree=2.1.2 treeshrink=1.3.9 fasttree=2.1.10 julia=1.7.1 gappa=0.7.1 trimal=1.4.1 openjdk raxml-ng) 
 	condaplat=$(conda info | grep "platform" | awk '{print $3}')
 	if [ "$condaplat" == "osx-arm64" ] ; then
 		echo "Installing conda environment on Mac OS X Apple Chip platform"

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,6 @@ else
         # install astral
         pushd $SCRIPTS_DIR/uDance/tools/ASTRAL
        	./make.sh > .astralInstallation.log 2>&1
-	    conda activate udance && java -D"java.library.path=lib/" -jar native_library_tester.jar
+        conda activate udance && java -D"java.library.path=lib/" -jar native_library_tester.jar
         popd
 fi

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ export SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd
 if conda info --envs | grep "udance" > /dev/null; then
         echo "conda environment udance exists"
 else
-	basecomm=$(echo conda create -y -c bioconda -c conda-forge --channel smirarab --name udance python=3.9  pip newick_utils=1.6 setuptools seqkit=2.1.0 scipy dendropy=4.5.2 pandas=1.3.0 snakemake raxml=8.2.12 iqtree=2.1.2 treeshrink=1.3.9 fasttree=2.1.10 julia=1.7.1 gappa=0.7.1 trimal=1.4.1 raxml-ng openjdk) 
+	basecomm=$(echo conda create -y -c bioconda -c conda-forge --channel smirarab --name udance python=3.9  pip newick_utils=1.6 setuptools seqkit=2.1.0 scipy dendropy=4.5.2 pandas=1.3.0 snakemake raxml=8.2.12 iqtree=2.1.2 treeshrink=1.3.9 fasttree=2.1.10 julia=1.7.1 gappa=0.7.1 trimal=1.4.1 raxml-ng) 
 	condaplat=$(conda info | grep "platform" | awk '{print $3}')
 	if [ "$condaplat" == "osx-arm64" ] ; then
 		echo "Installing conda environment on Mac OS X Apple Chip platform"

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,6 @@ else
         # install astral
         pushd $SCRIPTS_DIR/uDance/tools/ASTRAL
        	./make.sh > .astralInstallation.log 2>&1
-        conda activate udance && java -D"java.library.path=lib/" -jar native_library_tester.jar
+        java -D"java.library.path=lib/" -jar native_library_tester.jar
         popd
 fi

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ export SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd
 if conda info --envs | grep "udance" > /dev/null; then
         echo "conda environment udance exists"
 else
-	basecomm=$(echo conda create -y -c bioconda -c conda-forge --channel smirarab --name udance python=3.9  pip newick_utils=1.6 setuptools seqkit=2.1.0 scipy dendropy=4.5.2 pandas=1.3.0 snakemake raxml=8.2.12 iqtree=2.1.2 treeshrink=1.3.9 fasttree=2.1.10 julia=1.7.1 gappa=0.7.1 trimal=1.4.1 raxml-ng) 
+	basecomm=$(echo conda create -y -c bioconda -c conda-forge --channel smirarab --name udance python=3.9  pip newick_utils=1.6 setuptools seqkit=2.1.0 scipy dendropy=4.5.2 pandas=1.3.0 snakemake raxml=8.2.12 iqtree=2.1.2 treeshrink=1.3.9 fasttree=2.1.10 julia=1.7.1 gappa=0.7.1 trimal=1.4.1 raxml-ng openjdk) 
 	condaplat=$(conda info | grep "platform" | awk '{print $3}')
 	if [ "$condaplat" == "osx-arm64" ] ; then
 		echo "Installing conda environment on Mac OS X Apple Chip platform"
@@ -33,7 +33,6 @@ else
         # install astral
         pushd $SCRIPTS_DIR/uDance/tools/ASTRAL
        	./make.sh > .astralInstallation.log 2>&1
-	conda install openjdk
-	java -D"java.library.path=lib/" -jar native_library_tester.jar
+	    conda activate udance && java -D"java.library.path=lib/" -jar native_library_tester.jar
         popd
 fi

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,6 @@ else
         source activate udance
         conda activate udance
         pip install apples==2.0.11 kmeans1d==0.3.1
-	# install raxml-ng from the github release (conda conflict)
-	echo "Warning. if you want to use raxml-ng, please install it manually and make the executable "raxml-ng" available in the environment."
         # julia needs to download packages during the first run. Let's do it now while we are online :)
         julia $SCRIPTS_DIR/uDance/correction_multi.jl datasmall/alignments/p0309.fasta > /dev/null
         # install astral


### PR DESCRIPTION
Hey, Metin! I'm helping Rob Knight's lab run uDance on their cluster, and as part of that, I wanted to create a Docker container for it.

This PR includes the `Dockerfile` (as well as `.devcontainer` stuff needed to set up the environment automatically in VS Code / GitHub Codespaces).

It also adds `raxml-ng` to the `install.sh` script since RAxML-NG is on bioconda now without any conflicts.